### PR TITLE
Projectile despawning outside of map bounds

### DIFF
--- a/src/main/java/TestGrupp/Model/Asteroid.java
+++ b/src/main/java/TestGrupp/Model/Asteroid.java
@@ -1,23 +1,21 @@
 package TestGrupp.Model;
 
+import TestGrupp.Model.EntityComponents.OutOfBoundsDespawn;
+
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
-import java.awt.*;
-import java.awt.geom.Rectangle2D;
 
 public class Asteroid extends GameObject {
     private final int childAsteroids;
     private final PhysicsComponent physics;
     private final HealthComponent health;
-    private final ScreenDataSingleton screenDataSingleton;
+    private final OutOfBoundsDespawn outOfBoundsDespawn;
     private GameEventListener listener;
 
-    // Constructor
     public Asteroid(Point2d position, double rotation, double speed, int health, int childAsteroids, GameEventListener listener) {
         super(position, rotation, listener);
         this.childAsteroids = childAsteroids;
         this.listener = listener;
-        this.screenDataSingleton = ScreenDataSingleton.getInstance();
 
         TransformComponent transform = this.getTransform();
         transform.setPosition(position);
@@ -31,20 +29,13 @@ public class Asteroid extends GameObject {
         this.physics.setVelocity(initialVelocity);
 
         this.physics.setIsProjectile(true); // Asteroids should be treated as projectiles
-    }
 
-
-    private boolean isOnMap() {
-        Rectangle mapArea = screenDataSingleton.getMapArea();
-        Rectangle2D.Float boundingBox = this.getTransform().getBoundingBox();
-        return mapArea.intersects(boundingBox);
+        this.outOfBoundsDespawn = new OutOfBoundsDespawn();
     }
 
     public void update(double deltaTime) {
-        if (!isOnMap()) {
-            setActive(false);
-        }
         physics.update(deltaTime, this.getTransform());
+        outOfBoundsDespawn.update(this);
     }
 
     public void takeDamage(int damage) {
@@ -60,9 +51,7 @@ public class Asteroid extends GameObject {
                 listener.onAsteroidDestroyed(this.getTransform().getPosition(), 0);
             }
         }
-        //this.setActive(false);
     }
-
 
     public void onCollision(GameObject other) {
         if (other instanceof Projectile) {

--- a/src/main/java/TestGrupp/Model/EntityComponents/OutOfBoundsDespawn.java
+++ b/src/main/java/TestGrupp/Model/EntityComponents/OutOfBoundsDespawn.java
@@ -1,0 +1,27 @@
+package TestGrupp.Model.EntityComponents;
+
+import TestGrupp.Model.GameObject;
+import TestGrupp.Model.ScreenDataSingleton;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+
+public class OutOfBoundsDespawn {
+    private final ScreenDataSingleton screenDataSingleton;
+
+    public OutOfBoundsDespawn() {
+        this.screenDataSingleton = ScreenDataSingleton.getInstance();
+    }
+
+    public void update(GameObject gameObject) {
+        if (!isOnMap(gameObject)) {
+            gameObject.setActive(false);
+        }
+    }
+
+    private boolean isOnMap(GameObject gameObject) {
+        Rectangle mapArea = screenDataSingleton.getMapArea();
+        Rectangle2D.Float boundingBox = gameObject.getTransform().getBoundingBox();
+        return mapArea.intersects(boundingBox);
+    }
+}

--- a/src/main/java/TestGrupp/Model/Projectile.java
+++ b/src/main/java/TestGrupp/Model/Projectile.java
@@ -1,11 +1,14 @@
 package TestGrupp.Model;
 
+import TestGrupp.Model.EntityComponents.OutOfBoundsDespawn;
+
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
 
 public class Projectile extends GameObject {
 
     private final PhysicsComponent physics;
+    private final OutOfBoundsDespawn outOfBoundsDespawn;
     private int damage;
 
     private boolean isPlayerProjectile;
@@ -17,6 +20,7 @@ public class Projectile extends GameObject {
         this.isPlayerProjectile = playerProjectile;
         this.getTransform().setPosition(initialPosition);
         this.getTransform().setRotation(rotation);
+        this.outOfBoundsDespawn = new OutOfBoundsDespawn();
 
         // Calculate velocity based on the rotation and speed
         double velocityX = Math.cos(rotation) * speed;
@@ -45,6 +49,7 @@ public class Projectile extends GameObject {
     public void update(double deltaTime) {
         super.update(deltaTime);  // Update the base GameObject (position, etc.)
         physics.update(deltaTime, this.getTransform());  // Update the physics and apply velocity
+        outOfBoundsDespawn.update(this);
     }
 
     /**


### PR DESCRIPTION
Projectiles now despawn when they go outside of map bounds. Rewrote asteroid out of bounds cleanup code as a component which both asteroids and projectiles now implement.

This resolves the issue with significant lag when the player has been alive for some time