### PR TITLE
Fixed playership respawning at screen centre

### DIFF
--- a/src/main/java/TestGrupp/Model/Asteroid.java
+++ b/src/main/java/TestGrupp/Model/Asteroid.java
@@ -1,23 +1,21 @@
 package TestGrupp.Model;
 
+import TestGrupp.Model.EntityComponents.OutOfBoundsDespawn;
+
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
-import java.awt.*;
-import java.awt.geom.Rectangle2D;
 
 public class Asteroid extends GameObject {
     private final int childAsteroids;
     private final PhysicsComponent physics;
     private final HealthComponent health;
-    private final ScreenDataSingleton screenDataSingleton;
+    private final OutOfBoundsDespawn outOfBoundsDespawn;
     private GameEventListener listener;
 
-    // Constructor
     public Asteroid(Point2d position, double rotation, double speed, int health, int childAsteroids, GameEventListener listener) {
         super(position, rotation, listener);
         this.childAsteroids = childAsteroids;
         this.listener = listener;
-        this.screenDataSingleton = ScreenDataSingleton.getInstance();
 
         TransformComponent transform = this.getTransform();
         transform.setPosition(position);
@@ -31,20 +29,13 @@ public class Asteroid extends GameObject {
         this.physics.setVelocity(initialVelocity);
 
         this.physics.setIsProjectile(true); // Asteroids should be treated as projectiles
-    }
 
-
-    private boolean isOnMap() {
-        Rectangle mapArea = screenDataSingleton.getMapArea();
-        Rectangle2D.Float boundingBox = this.getTransform().getBoundingBox();
-        return mapArea.intersects(boundingBox);
+        this.outOfBoundsDespawn = new OutOfBoundsDespawn();
     }
 
     public void update(double deltaTime) {
-        if (!isOnMap()) {
-            setActive(false);
-        }
         physics.update(deltaTime, this.getTransform());
+        outOfBoundsDespawn.update(this);
     }
 
     public void takeDamage(int damage) {
@@ -60,9 +51,7 @@ public class Asteroid extends GameObject {
                 listener.onAsteroidDestroyed(this.getTransform().getPosition(), 0);
             }
         }
-        //this.setActive(false);
     }
-
 
     public void onCollision(GameObject other) {
         if (other instanceof Projectile) {

--- a/src/main/java/TestGrupp/Model/EntityComponents/OutOfBoundsDespawn.java
+++ b/src/main/java/TestGrupp/Model/EntityComponents/OutOfBoundsDespawn.java
@@ -1,0 +1,27 @@
+package TestGrupp.Model.EntityComponents;
+
+import TestGrupp.Model.GameObject;
+import TestGrupp.Model.ScreenDataSingleton;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+
+public class OutOfBoundsDespawn {
+    private final ScreenDataSingleton screenDataSingleton;
+
+    public OutOfBoundsDespawn() {
+        this.screenDataSingleton = ScreenDataSingleton.getInstance();
+    }
+
+    public void update(GameObject gameObject) {
+        if (!isOnMap(gameObject)) {
+            gameObject.setActive(false);
+        }
+    }
+
+    private boolean isOnMap(GameObject gameObject) {
+        Rectangle mapArea = screenDataSingleton.getMapArea();
+        Rectangle2D.Float boundingBox = gameObject.getTransform().getBoundingBox();
+        return mapArea.intersects(boundingBox);
+    }
+}

--- a/src/main/java/TestGrupp/Model/GameModel.java
+++ b/src/main/java/TestGrupp/Model/GameModel.java
@@ -1,3 +1,5 @@
+
+
 package TestGrupp.Model;
 
 import javax.vecmath.Point2d;
@@ -37,6 +39,7 @@ public class GameModel implements GameEventListener, Subject  {
         this.screenCenter = new Point2d(0, 0);
         this.observers = new ArrayList<>();
         this.collisionManager = new CollisionManager(gameObjects);
+
 
         Properties properties = getGameProperties();
         int playerWidth = Integer.parseInt(properties.getProperty("PlayerShip.width"));
@@ -92,8 +95,10 @@ public class GameModel implements GameEventListener, Subject  {
         score.resetScore();
 
         // Respawn the player at the initial position
-        this.playerShip = new PlayerShip(screenCenter, 0, this);
-        playerShip.setPos(screenCenter); // Set player position to center
+        Point2d startPos = new Point2d(screenCenter);
+        this.playerShip = new PlayerShip(startPos, 0, this);
+        System.out.printf("Screencenter: %s\n", screenCenter);
+        //playerShip.setPos(screenCenter); // Set player position to center
         addGameObject(playerShip);
 
         // Reinitialize the EnemySpawner
@@ -160,7 +165,7 @@ public class GameModel implements GameEventListener, Subject  {
         score.updateScoreBasedOnTime();
 
         notifyObservers(gameObjectDTOs, score.getScore(), playerShip.getCollectedPowerUps());
-  
+
 
 
     }
@@ -204,7 +209,8 @@ public class GameModel implements GameEventListener, Subject  {
 
     public void setScreenCenter(Point2d center) {
         this.screenCenter = center;
-        getPlayerShip().setPos(center);
+        Point2d startPos = new Point2d(center);
+        getPlayerShip().setPos(startPos);
 
     }
 

--- a/src/main/java/TestGrupp/Model/Projectile.java
+++ b/src/main/java/TestGrupp/Model/Projectile.java
@@ -1,11 +1,14 @@
 package TestGrupp.Model;
 
+import TestGrupp.Model.EntityComponents.OutOfBoundsDespawn;
+
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
 
 public class Projectile extends GameObject {
 
     private final PhysicsComponent physics;
+    private final OutOfBoundsDespawn outOfBoundsDespawn;
     private int damage;
 
     private boolean isPlayerProjectile;
@@ -17,6 +20,7 @@ public class Projectile extends GameObject {
         this.isPlayerProjectile = playerProjectile;
         this.getTransform().setPosition(initialPosition);
         this.getTransform().setRotation(rotation);
+        this.outOfBoundsDespawn = new OutOfBoundsDespawn();
 
         // Calculate velocity based on the rotation and speed
         double velocityX = Math.cos(rotation) * speed;
@@ -45,6 +49,7 @@ public class Projectile extends GameObject {
     public void update(double deltaTime) {
         super.update(deltaTime);  // Update the base GameObject (position, etc.)
         physics.update(deltaTime, this.getTransform());  // Update the physics and apply velocity
+        outOfBoundsDespawn.update(this);
     }
 
     /**


### PR DESCRIPTION
The player did not respawn at the screen center because the first screen center position instance was passed by reference. This results in this instance becoming the instance the player uses for their position. To resolve this we make a new position instance with the values of the screen center position, passing screen center "by copy"